### PR TITLE
feat: introduce sales checkout wizard component and its initial DTE s…

### DIFF
--- a/frontend/features/sales/components/SalesCheckoutWizard.tsx
+++ b/frontend/features/sales/components/SalesCheckoutWizard.tsx
@@ -426,7 +426,13 @@ export function SalesCheckoutWizard({
 
         // Step: DTE
         if (step === currentStepNum) {
-            return <Step1_DTE dteData={dteData} setDteData={setDteData} />
+            return (
+                <Step1_DTE
+                    dteData={dteData}
+                    setDteData={setDteData}
+                    isDefaultCustomer={!!selectedCustomer?.is_default_customer}
+                />
+            )
         }
         currentStepNum++;
 

--- a/frontend/features/sales/components/checkout/Step1_DTE.tsx
+++ b/frontend/features/sales/components/checkout/Step1_DTE.tsx
@@ -14,9 +14,10 @@ interface Step1_DTEProps {
     dteData: any
     setDteData: (data: any) => void
     isPurchase?: boolean
+    isDefaultCustomer?: boolean
 }
 
-export function Step1_DTE({ dteData, setDteData, isPurchase = false }: Step1_DTEProps) {
+export function Step1_DTE({ dteData, setDteData, isPurchase = false, isDefaultCustomer = false }: Step1_DTEProps) {
     const { validateFolio, isValidating, validationResult, clearValidation } = useFolioValidation()
 
     // Validate folio when number changes
@@ -27,6 +28,13 @@ export function Step1_DTE({ dteData, setDteData, isPurchase = false }: Step1_DTE
             clearValidation()
         }
     }, [dteData.number, dteData.type, dteData.isPending, validateFolio, clearValidation])
+
+    // Enforce BOLETA for default customers
+    useEffect(() => {
+        if (isDefaultCustomer && dteData.type !== 'BOLETA') {
+            setDteData({ ...dteData, type: 'BOLETA' })
+        }
+    }, [isDefaultCustomer, dteData.type, setDteData])
 
     return (
         <div className="space-y-6">
@@ -39,11 +47,24 @@ export function Step1_DTE({ dteData, setDteData, isPurchase = false }: Step1_DTE
                     Ingrese la información relacionada al DTE y adjunte el respaldo legal.
                 </p>
             </div>
+
+            {isDefaultCustomer && (
+                <Alert className="bg-amber-50 border-amber-200 text-amber-800 py-3">
+                    <AlertCircle className="h-4 w-4 text-amber-600" />
+                    <AlertDescription className="text-xs font-medium">
+                        El cliente por defecto solo permite emisión de <strong>Boleta Electrónica</strong>.
+                    </AlertDescription>
+                </Alert>
+            )}
+
             <div className="space-y-4">
                 <RadioGroup
                     value={dteData.type}
                     onValueChange={(val) => setDteData({ ...dteData, type: val })}
-                    className="grid grid-cols-2 gap-4"
+                    className={cn(
+                        "grid gap-4",
+                        isDefaultCustomer ? "grid-cols-1" : "grid-cols-2"
+                    )}
                 >
                     <Label
                         htmlFor="type-boleta"
@@ -54,33 +75,38 @@ export function Step1_DTE({ dteData, setDteData, isPurchase = false }: Step1_DTE
                         <span className="text-sm font-medium">Boleta Electrónica</span>
                         <span className="text-[10px] text-muted-foreground mt-1 text-center">Código SII: 39</span>
                     </Label>
-                    <Label
-                        htmlFor="type-factura"
-                        className={`flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary cursor-pointer ${dteData.type === 'FACTURA' ? 'border-primary' : ''}`}
-                    >
-                        <RadioGroupItem value="FACTURA" id="type-factura" className="sr-only" />
-                        <FileText className="mb-3 h-6 w-6" />
-                        <span className="text-sm font-medium">Factura Electrónica</span>
-                        <span className="text-[10px] text-muted-foreground mt-1 text-center">Código SII: 33</span>
-                    </Label>
-                    <Label
-                        htmlFor="type-boleta-exenta"
-                        className={`flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary cursor-pointer ${dteData.type === 'BOLETA_EXENTA' ? 'border-primary' : ''}`}
-                    >
-                        <RadioGroupItem value="BOLETA_EXENTA" id="type-boleta-exenta" className="sr-only" />
-                        <Receipt className="mb-3 h-6 w-6 text-amber-600" />
-                        <span className="text-sm font-medium">Boleta Exenta</span>
-                        <span className="text-[10px] text-muted-foreground mt-1 text-center">Código SII: 41</span>
-                    </Label>
-                    <Label
-                        htmlFor="type-factura-exenta"
-                        className={`flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary cursor-pointer ${dteData.type === 'FACTURA_EXENTA' ? 'border-primary' : ''}`}
-                    >
-                        <RadioGroupItem value="FACTURA_EXENTA" id="type-factura-exenta" className="sr-only" />
-                        <FileText className="mb-3 h-6 w-6 text-amber-600" />
-                        <span className="text-sm font-medium">Factura Exenta</span>
-                        <span className="text-[10px] text-muted-foreground mt-1 text-center">Código SII: 34</span>
-                    </Label>
+
+                    {!isDefaultCustomer && (
+                        <>
+                            <Label
+                                htmlFor="type-factura"
+                                className={`flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary cursor-pointer ${dteData.type === 'FACTURA' ? 'border-primary' : ''}`}
+                            >
+                                <RadioGroupItem value="FACTURA" id="type-factura" className="sr-only" />
+                                <FileText className="mb-3 h-6 w-6" />
+                                <span className="text-sm font-medium">Factura Electrónica</span>
+                                <span className="text-[10px] text-muted-foreground mt-1 text-center">Código SII: 33</span>
+                            </Label>
+                            <Label
+                                htmlFor="type-boleta-exenta"
+                                className={`flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary cursor-pointer ${dteData.type === 'BOLETA_EXENTA' ? 'border-primary' : ''}`}
+                            >
+                                <RadioGroupItem value="BOLETA_EXENTA" id="type-boleta-exenta" className="sr-only" />
+                                <Receipt className="mb-3 h-6 w-6 text-amber-600" />
+                                <span className="text-sm font-medium">Boleta Exenta</span>
+                                <span className="text-[10px] text-muted-foreground mt-1 text-center">Código SII: 41</span>
+                            </Label>
+                            <Label
+                                htmlFor="type-factura-exenta"
+                                className={`flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary cursor-pointer ${dteData.type === 'FACTURA_EXENTA' ? 'border-primary' : ''}`}
+                            >
+                                <RadioGroupItem value="FACTURA_EXENTA" id="type-factura-exenta" className="sr-only" />
+                                <FileText className="mb-3 h-6 w-6 text-amber-600" />
+                                <span className="text-sm font-medium">Factura Exenta</span>
+                                <span className="text-[10px] text-muted-foreground mt-1 text-center">Código SII: 34</span>
+                            </Label>
+                        </>
+                    )}
                 </RadioGroup>
             </div>
 


### PR DESCRIPTION
He implementado la restricción de documentos (DTE) para el cliente por defecto en el wizard de ventas de POS. Aquí tienes un resumen de los cambios:

1. Restricción en la Interfaz (UI)
En el paso de Registro de Documento, si el cliente es el genérico, ahora solo se muestra la opción de Boleta Electrónica.
Las opciones de Factura, Boleta Exenta y Factura Exenta se ocultan automáticamente para evitar selecciones erróneas.
Se añadió un mensaje de alerta informativo: "El cliente por defecto solo permite emisión de Boleta Electrónica".
2. Cumplimiento Lógico (Enforcement)
Se implementó un hook useEffect que fuerza el tipo de documento a BOLETA en el estado interno si detecta que el cliente es el predeterminado, asegurando que no se arrastre información de ventas anteriores o selecciones manuales previas.
3. Integración en el Wizard
Se actualizó el componente principal 

SalesCheckoutWizard.tsx
 para detectar y propagar correctamente el flag isDefaultCustomer (derivado de selectedCustomer.is_default_customer) hacia los pasos internos de la transacción.
