### PR TITLE
fix(frontend): P0 correctness from Big O audit (#170)

### DIFF
--- a/docs/40-quality/complexity-map.md
+++ b/docs/40-quality/complexity-map.md
@@ -144,9 +144,9 @@ Formato de fila: `clave (archivo:línea) | n | bounded-ness | round-trips | row-
 
 | Archivo | patrón | riesgo | remediación |
 |---|---|---|---|
-| `features/pos/hooks/useProducts.ts:49` `page_size:2000` | **bug de correctitud**: el backend capa a 200 → la búsqueda POS solo ve ~200 productos | **alto** | quitar page_size o añadir búsqueda server-side |
-| `SalesOrdersView.tsx:67,74`, `ProductClientView.tsx:118`, `TreasuryMovementsClientView.tsx:50`, `DocumentsClientView.tsx:39`, `BankMovementsClientView.tsx:41`, `MovementClientView.tsx:37` `page_size:5000` (grouping) | grouping client-side capado a 200 → conteos de grupo incorrectos entre 201-5000 | medio (correctness) | grouping server-side o deshabilitarlo cuando count>200 |
-| `purchasingApi.ts:139` (`getPurchasableProducts`), `contactsApi.ts:19`, `useVariants.ts:41` | consumen list paginado sin page_size → truncado silencioso a página 1 | medio (correctness) | page_size explícito + búsqueda server-side |
+| `features/pos/hooks/useProducts.ts:49` `page_size:2000` | **bug de correctitud**: el backend capa a 200 → la búsqueda POS solo ve ~200 productos | **alto** | **corregido** — búsqueda server-side (`search`/`category` debounced) + `page_size:200` (2026-08-13) |
+| `SalesOrdersView.tsx:67,74`, `ProductClientView.tsx:118`, `TreasuryMovementsClientView.tsx:50`, `DocumentsClientView.tsx:39`, `BankMovementsClientView.tsx:41`, `MovementClientView.tsx:37` `page_size:5000` (grouping) | grouping client-side capado a 200 → conteos de grupo incorrectos entre 201-5000 | medio (correctness) | **corregido** — guard recalibrado a `count>200` (cap real) en las 6 vistas + `useGroupByPagination.ts:4` (2026-08-13); grouping server-side sigue pendiente (P1) |
+| `purchasingApi.ts:139` (`getPurchasableProducts`), `contactsApi.ts:19`, `useVariants.ts:41` | consumen list paginado sin page_size → truncado silencioso a página 1 | medio (correctness) | **corregido** — `page_size:200` explícito (2026-08-13) |
 | `accountingApi.ts:6` `getAccounts`, `treasuryApi.ts:129` `getAccounts`, `hrApi.ts:68` `getEmployees` | datasets sin paginar, render O(n) | medio (crecen) | paginar o search server-side |
 | `useAttributes.ts:38-49` | join `attrs.map(vals.filter)` = O(a·v) sin cap | bajo-medio | Map por attribute |
 | `.find`/`.indexOf` en `.map` (PurchaseOrderModal:315, Step4_Receipt:243, BOMDrawer:585, ActionCategory:225, CostCalculatorDrawer:146, PosTerminalDrawer:103, entity-fields:940, DataTable:260, ProductGrid:87) | O(n²) sobre arrays ≤200 | bajo (etiqueta O(1) efectivo) | — |
@@ -206,9 +206,9 @@ Matriz 2×2 por endpoint (empírico × asintótico); rollup por app = peor fila.
 Prioridad = riesgo × radio de impacto (riesgo {bajo,medio,alto} = clase × bounded-ness; impacto 1-5 = endpoints × frecuencia). Fix de una frase; issues aparte.
 
 **P0 — correctitud (frontend):**
-1. Bug POS: `useProducts.ts:49` (page_size 2000 → 200). 
-2. Grouping `page_size:5000` (6 views) → agrupación incompleta 201-5000.
-3. Consumidores sin page_size (getPurchasableProducts, getContacts, useVariants) → truncado silencioso.
+1. Bug POS: `useProducts.ts:49` (page_size 2000 → 200). **Implementado 2026-08-13** (búsqueda server-side). 
+2. Grouping `page_size:5000` (6 views) → agrupación incompleta 201-5000. **Implementado 2026-08-13** (guard >200).
+3. Consumidores sin page_size (getPurchasableProducts, getContacts, useVariants) → truncado silencioso. **Implementado 2026-08-13** (page_size 200).
 
 **P1 — unbounded interactivo de mayor impacto:**
 4. Tax `documents`/`get_declaration_documents` (selectors.py:18): serializador ligero + prefetch o export paginado.

--- a/frontend/features/contacts/api/contactsApi.ts
+++ b/frontend/features/contacts/api/contactsApi.ts
@@ -15,6 +15,7 @@ export const contactsApi = {
         if (filters?.tax_id) params.append('tax_id', filters.tax_id)
         if (filters?.is_default_customer !== undefined) params.append('is_default_customer', String(filters.is_default_customer))
         if (filters?.is_default_vendor !== undefined) params.append('is_default_vendor', String(filters.is_default_vendor))
+        params.set('page_size', '200')
 
         const { data } = await api.get<{ results: Contact[] }>('/contacts/', { params })
         return data.results

--- a/frontend/features/inventory/components/DocumentsClientView.tsx
+++ b/frontend/features/inventory/components/DocumentsClientView.tsx
@@ -36,10 +36,10 @@ export function DocumentsClientView({ documentTypeFilter, createAction }: Docume
     const { page, documents, totalCount, isLoading, refetch } = useInventoryDocuments({
         ...allFilters,
         page: isGrouping ? 1 : pageState.pageIndex + 1,
-        page_size: isGrouping ? 5000 : pageState.pageSize,
+        page_size: isGrouping ? 200 : pageState.pageSize,
     })
 
-    const isOverLimit = isGrouping && totalCount > 5000
+    const isOverLimit = isGrouping && totalCount > 200
     const effectiveGrouping = isGrouping && !isOverLimit
 
     useEffect(() => {
@@ -100,7 +100,7 @@ export function DocumentsClientView({ documentTypeFilter, createAction }: Docume
                     manualPagination={!effectiveGrouping}
                     pageCount={effectiveGrouping ? 1 : page ? Math.ceil(page.count / page.pageSize) : 0}
                     rowCount={totalCount}
-                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 5000 } : pageState}
+                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 200 } : pageState}
                     onPaginationChange={effectiveGrouping ? undefined : setPageState}
                     unifiedSearch={<UnifiedSearchBar
                         config={documentUnifiedSearchDef}

--- a/frontend/features/inventory/components/MovementClientView.tsx
+++ b/frontend/features/inventory/components/MovementClientView.tsx
@@ -34,10 +34,10 @@ export function MovementClientView({ createAction }: MovementClientViewProps) {
     const { page, moves, totalCount, isLoading } = useStockMoves({
         ...search.filters,
         page: isGrouping ? 1 : pageState.pageIndex + 1,
-        page_size: isGrouping ? 5000 : pageState.pageSize,
+        page_size: isGrouping ? 200 : pageState.pageSize,
     })
 
-    const isOverLimit = isGrouping && totalCount > 5000
+    const isOverLimit = isGrouping && totalCount > 200
     const effectiveGrouping = isGrouping && !isOverLimit
 
     useEffect(() => {
@@ -311,7 +311,7 @@ export function MovementClientView({ createAction }: MovementClientViewProps) {
                     manualPagination={!effectiveGrouping}
                     pageCount={effectiveGrouping ? 1 : page ? Math.ceil(page.count / page.pageSize) : 0}
                     rowCount={totalCount}
-                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 5000 } : pageState}
+                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 200 } : pageState}
                     onPaginationChange={effectiveGrouping ? undefined : setPageState}
                     unifiedSearch={<UnifiedSearchBar
                         config={stockMoveUnifiedSearchDef}

--- a/frontend/features/inventory/components/ProductClientView.tsx
+++ b/frontend/features/inventory/components/ProductClientView.tsx
@@ -115,12 +115,12 @@ export function ProductClientView({ externalOpen, onExternalOpenChange, createAc
     const { page, products, isLoading, refetch, updateProduct } = useProducts({
         filters,
         page: isGrouping ? 1 : pageState.pageIndex + 1,
-        page_size: isGrouping ? 5000 : pageState.pageSize,
+        page_size: isGrouping ? 200 : pageState.pageSize,
         initialData: initialProducts ? { results: initialProducts, count: initialProducts.length } as Page<Product> : undefined,
     })
 
     const totalCount = page?.count ?? 0
-    const isOverLimit = isGrouping && totalCount > 5000
+    const isOverLimit = isGrouping && totalCount > 200
     const effectiveGrouping = isGrouping && !isOverLimit
 
     useEffect(() => {
@@ -579,7 +579,7 @@ export function ProductClientView({ externalOpen, onExternalOpenChange, createAc
                     manualPagination={!effectiveGrouping}
                     pageCount={effectiveGrouping ? 1 : page ? Math.ceil(page.count / page.pageSize) : 0}
                     rowCount={page?.count ?? 0}
-                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 5000 } : pageState}
+                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 200 } : pageState}
                     onPaginationChange={effectiveGrouping ? undefined : setPageState}
                     unifiedSearch={<UnifiedSearchBar
                         config={config}

--- a/frontend/features/inventory/hooks/useVariants.ts
+++ b/frontend/features/inventory/hooks/useVariants.ts
@@ -31,6 +31,7 @@ export function useVariants({ productId, enabled = true, activeOnly = true, extr
             if (activeOnly) {
                 params.append('is_active', 'true')
             }
+            params.append('page_size', '200')
 
             Object.entries(extraParams).forEach(([key, value]) => {
                 if (value !== undefined && value !== null) {

--- a/frontend/features/pos/hooks/queryKeys.ts
+++ b/frontend/features/pos/hooks/queryKeys.ts
@@ -58,7 +58,7 @@ export const POS_KEYS = {
   products: {
     all: ['products'] as const,
     lists: () => [...POS_KEYS.products.all, 'list'] as const,
-    list: (filters?: { is_active?: boolean; can_be_sold?: boolean }) => [...POS_KEYS.products.lists(), { filters }] as const,
+    list: (filters?: { is_active?: boolean; can_be_sold?: boolean; search?: string; category?: number }) => [...POS_KEYS.products.lists(), { filters }] as const,
     details: () => [...POS_KEYS.products.all, 'detail'] as const,
     detail: (id: number) => [...POS_KEYS.products.details(), id] as const,
   },

--- a/frontend/features/pos/hooks/useProducts.ts
+++ b/frontend/features/pos/hooks/useProducts.ts
@@ -11,6 +11,7 @@ import { useRealtime, useEntitySubscription } from '@/features/realtime'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { invalidateCrossFeature } from '@/lib/invalidation'
 import { inventoryApi } from '@/features/inventory'
+import { useDebounce } from '@/hooks/useDebounce'
 import { POS_KEYS } from './queryKeys'
 
 const EMPTY_ARRAY: Product[] = []
@@ -39,19 +40,23 @@ export function useProducts() {
     const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null)
     const [limits, setLimits] = useState<StockLimits>({})
 
+    const debouncedSearchTerm = useDebounce(searchTerm, 300)
+
     // 1. Fetch Products with React Query (Shared Cache)
     const { data: products = EMPTY_ARRAY, isLoading: loadingProducts } = useQuery({
-        queryKey: POS_KEYS.products.list({ is_active: true, can_be_sold: true }),
+        queryKey: POS_KEYS.products.list({ is_active: true, can_be_sold: true, search: debouncedSearchTerm, category: selectedCategoryId ?? undefined }),
         queryFn: async () => {
             const page = await inventoryApi.getProducts({
                 is_active: true,
                 can_be_sold: true,
-                page_size: 2000, // Ensure we get all sellable items in one go for instant search
+                search: debouncedSearchTerm || undefined,
+                category: selectedCategoryId ?? undefined,
+                page_size: 200,
                 fields: 'id,name,sale_price,sale_price_gross,image,uom_name,internal_code,barcode,product_type,track_inventory,requires_advanced_manufacturing,category,uom,available_uoms,is_favorite,has_bom,mfg_auto_finalize,mfg_enable_prepress,mfg_enable_press,mfg_enable_postpress,qty_available,manufacturable_quantity'
             })
             return (page.results ?? []) as unknown as Product[]
         },
-        staleTime: 1000 * 60 * 5, 
+        staleTime: 1000 * 60 * 5,
     })
 
     // Sync global state if needed (though we should ideally use React Query data directly)
@@ -88,11 +93,9 @@ export function useProducts() {
         }
     }, [loadingProducts, loadingCategories, loadingUoms, setLoading])
 
-    // Filtered products based on search and category
     const filteredProducts = useMemo(() => {
-        let filtered = [...products]
+        const filtered = [...products]
 
-        // 1. Sort by favorite status first (Frontend fallback for optimistic updates)
         filtered.sort((a, b) => {
             const aFav = a.is_favorite
             const bFav = b.is_favorite
@@ -101,27 +104,8 @@ export function useProducts() {
             return 0
         })
 
-        // 2. Filter by category
-        if (selectedCategoryId !== null) {
-            filtered = filtered.filter(p => {
-                const pCat = p.category
-                const catId = typeof pCat === 'object' ? pCat?.id : pCat
-                return catId === selectedCategoryId
-            })
-        }
-
-        // 3. Filter by search term
-        if (searchTerm.trim()) {
-            const term = searchTerm.toLowerCase()
-            filtered = filtered.filter(p =>
-                (p.name && p.name.toLowerCase().includes(term)) ||
-                (p.code && p.code.toLowerCase().includes(term)) ||
-                (p.internal_code && p.internal_code.toLowerCase().includes(term))
-            )
-        }
-
         return filtered
-    }, [products, searchTerm, selectedCategoryId])
+    }, [products])
 
     const refreshProducts = useCallback(async (silent = false) => {
         if (!silent) setLoading(true)

--- a/frontend/features/purchasing/api/purchasingApi.ts
+++ b/frontend/features/purchasing/api/purchasingApi.ts
@@ -137,7 +137,7 @@ export const purchasingApi = {
     // ========== Inventory ==========
 
     getPurchasableProducts: async (): Promise<Record<string, unknown>[]> => {
-        const res = await api.get<{ results: Record<string, unknown>[] }>('/inventory/products/?can_be_purchased=true')
+        const res = await api.get<{ results: Record<string, unknown>[] }>('/inventory/products/?can_be_purchased=true&page_size=200')
         return res.data.results
     },
 

--- a/frontend/features/sales/components/SalesOrdersView.tsx
+++ b/frontend/features/sales/components/SalesOrdersView.tsx
@@ -64,19 +64,19 @@ export function SalesOrdersView({ viewMode, posSessionId, onSelectOrder, selecte
             ...(search.filters as SaleOrderFilters),
             pos_session: posSessionId || undefined,
             page: isGrouping ? 1 : pageState.pageIndex + 1,
-            page_size: isGrouping ? 5000 : pageState.pageSize,
+            page_size: isGrouping ? 200 : pageState.pageSize,
         },
     })
     const { page: pageNotes, notes, isLoading: isLoadingNotes, isRefetching: isRefetchingNotes } = useSalesNotes({
         filters: {
             ...(search.filters as Record<string, string>),
             page: isGrouping ? 1 : pageStateNotes.pageIndex + 1,
-            page_size: isGrouping ? 5000 : pageStateNotes.pageSize,
+            page_size: isGrouping ? 200 : pageStateNotes.pageSize,
         }
     })
 
     const totalCount = viewMode === 'orders' ? (page?.count ?? 0) : (pageNotes?.count ?? 0)
-    const isOverLimit = isGrouping && totalCount > 5000
+    const isOverLimit = isGrouping && totalCount > 200
     const effectiveGrouping = isGrouping && !isOverLimit
 
     useEffect(() => {
@@ -410,7 +410,7 @@ export function SalesOrdersView({ viewMode, posSessionId, onSelectOrder, selecte
                         : (pageNotes ? Math.ceil(pageNotes.count / pageNotes.pageSize) : 0)
                     }
                     rowCount={viewMode === 'orders' ? (page?.count ?? 0) : (pageNotes?.count ?? 0)}
-                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 5000 } : viewMode === 'orders' ? pageState : pageStateNotes}
+                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 200 } : viewMode === 'orders' ? pageState : pageStateNotes}
                     onPaginationChange={effectiveGrouping ? undefined : (viewMode === 'orders' ? setPageState : setPageStateNotes) as unknown as React.Dispatch<React.SetStateAction<{ pageIndex: number; pageSize: number }>>}
                     unifiedSearch={<UnifiedSearchBar
                         config={unifiedSearchDef}

--- a/frontend/features/treasury/components/BankMovementsClientView.tsx
+++ b/frontend/features/treasury/components/BankMovementsClientView.tsx
@@ -38,10 +38,10 @@ export function BankMovementsClientView({ bankId }: BankMovementsClientViewProps
     const { page, movements, totalCount, isLoading } = useTreasuryMovements({
         ...(allFilters as TreasuryMovementFilters),
         page: isGrouping ? 1 : pageState.pageIndex + 1,
-        page_size: isGrouping ? 5000 : pageState.pageSize,
+        page_size: isGrouping ? 200 : pageState.pageSize,
     })
 
-    const isOverLimit = isGrouping && totalCount > 5000
+    const isOverLimit = isGrouping && totalCount > 200
     const effectiveGrouping = isGrouping && !isOverLimit
 
     useEffect(() => {
@@ -86,7 +86,7 @@ export function BankMovementsClientView({ bankId }: BankMovementsClientViewProps
                     manualPagination={!effectiveGrouping}
                     pageCount={effectiveGrouping ? 1 : page ? Math.ceil(page.count / page.pageSize) : 0}
                     rowCount={totalCount}
-                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 5000 } : pageState}
+                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 200 } : pageState}
                     onPaginationChange={effectiveGrouping ? undefined : setPageState}
                     unifiedSearch={<UnifiedSearchBar
                         config={treasuryMovementsUnifiedSearchDef}

--- a/frontend/features/treasury/components/TreasuryMovementsClientView.tsx
+++ b/frontend/features/treasury/components/TreasuryMovementsClientView.tsx
@@ -47,10 +47,10 @@ export function TreasuryMovementsClientView({ externalOpen, createAction }: Trea
     const { page, movements, totalCount, isLoading, refetch } = useTreasuryMovements({
         ...(allFilters as TreasuryMovementFilters),
         page: isGrouping ? 1 : pageState.pageIndex + 1,
-        page_size: isGrouping ? 5000 : pageState.pageSize,
+        page_size: isGrouping ? 200 : pageState.pageSize,
     })
 
-    const isOverLimit = isGrouping && totalCount > 5000
+    const isOverLimit = isGrouping && totalCount > 200
     const effectiveGrouping = isGrouping && !isOverLimit
 
     useEffect(() => {
@@ -377,7 +377,7 @@ export function TreasuryMovementsClientView({ externalOpen, createAction }: Trea
                     manualPagination={!effectiveGrouping}
                     pageCount={effectiveGrouping ? 1 : page ? Math.ceil(page.count / page.pageSize) : 0}
                     rowCount={totalCount}
-                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 5000 } : pageState}
+                    pagination={effectiveGrouping ? { pageIndex: 0, pageSize: 200 } : pageState}
                     onPaginationChange={effectiveGrouping ? undefined : setPageState}
                     unifiedSearch={<UnifiedSearchBar
                         config={treasuryMovementsUnifiedSearchDef}

--- a/frontend/hooks/useGroupByPagination.ts
+++ b/frontend/hooks/useGroupByPagination.ts
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 
-const MAX_GROUP_BY_RECORDS = 5000
+const MAX_GROUP_BY_RECORDS = 200
 
 interface UseGroupByPaginationOptions {
   totalCount: number


### PR DESCRIPTION
## Resumen
Remediación P0 del complexity-map (issue #170) — 3 bugs de correctitud frontend. Todo frontend, sin cambios de contrato ni de cap (200 intacto → sin ADR).

## Cambios
- **POS** (`useProducts.ts`): búsqueda y categoría ahora **server-side** (debounced 300ms) con `page_size:200`; se elimina el filtrado client-side que solo veía los primeros 200 productos capados por el backend. `queryKeys.ts` tipo ampliado para `search`/`category`.
- **Grouping**: guard recalibrado de `count>5000` a `count>200` (cap real de `StandardResultsSetPagination`) en las 6 vistas + constante de `useGroupByPagination`. Agrupar >200 queda deshabilitado (correctitud); grouping server-side queda como follow-up P1.
- **Truncado silencioso**: `page_size:200` explícito en `getPurchasableProducts`, `getContacts`, `useVariants`.
- **complexity-map.md**: filas de §2.6 y ítems P0 de §5 marcados como implementados (nota de mantenimiento).

## Verificación
- `npm run type-check` ✅
- `npm run lint`: 0 errores, 0 warnings nuevos (839 pre-existentes)
- `npm run test` scope (pos/inventory/sales/contacts/purchasing/treasury/hooks): 29/29 ✅
- Closes #1 (child P0), #2 (child P0), #3 (child P0) del epic #170